### PR TITLE
Add support for `-A` and `-B` arguments

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -57,8 +57,6 @@ fn get_system_default_first_workday() -> Option<Weekday> {
     if let Some(dict) = plist.as_dictionary() {
         if let Some(Value::Dictionary(calendars)) = dict.get("AppleFirstWeekday") {
             if let Some(Value::Integer(first_weekday)) = calendars.get("gregorian") {
-                println!("First weekday: {:?}", first_weekday);
-
                 return match first_weekday.as_signed()? {
                     1 => Some(Weekday::Sun),
                     2 => Some(Weekday::Mon),

--- a/src/main.rs
+++ b/src/main.rs
@@ -151,48 +151,24 @@ struct Month {
 }
 
 impl Month {
-    fn print(&self) -> String {
-        let start_date = self.start_date;
-
-        let mut output = String::new();
-
+    fn print_header(&self, output: &mut String) {
         output.push_str(&format!(
             "{:^20}\n",
-            format!("{} {}", start_date.format("%B"), start_date.year())
+            format!(
+                "{} {}",
+                self.start_date.format("%B"),
+                self.start_date.year()
+            )
         ));
+    }
 
+    fn print_weekday_header(&self, output: &mut String) {
         match &self.first_day_of_week {
             Weekday::Mon => {
                 output.push_str("Mo Tu We Th Fr Sa Su\n");
-
-                for week in &self.weeks {
-                    output.push_str(&format!(
-                        "{} {} {} {} {} {} {}\n",
-                        format_date(week.monday),
-                        format_date(week.tuesday),
-                        format_date(week.wednesday),
-                        format_date(week.thursday),
-                        format_date(week.friday),
-                        format_date(week.saturday),
-                        format_date(week.sunday)
-                    ));
-                }
             }
             Weekday::Sun => {
                 output.push_str("Su Mo Tu We Th Fr Sa\n");
-
-                for week in &self.weeks {
-                    output.push_str(&format!(
-                        "{} {} {} {} {} {} {}\n",
-                        format_date(week.sunday),
-                        format_date(week.monday),
-                        format_date(week.tuesday),
-                        format_date(week.wednesday),
-                        format_date(week.thursday),
-                        format_date(week.friday),
-                        format_date(week.saturday),
-                    ));
-                }
             }
 
             _ => {
@@ -202,6 +178,18 @@ impl Month {
                 );
             }
         };
+    }
+
+    fn print(&self) -> String {
+        let mut output = String::new();
+
+        self.print_header(&mut output);
+        self.print_weekday_header(&mut output);
+
+        for week in &self.weeks {
+            week.print(self.first_day_of_week, &mut output);
+            output.push('\n');
+        }
 
         output
     }
@@ -252,6 +240,39 @@ impl Week {
             && self.friday.is_none()
             && self.saturday.is_none()
             && self.sunday.is_none()
+    }
+
+    fn print(&self, first_day_of_week: Weekday, output: &mut String) {
+        match first_day_of_week {
+            Weekday::Mon => {
+                output.push_str(&format!(
+                    "{} {} {} {} {} {} {}",
+                    format_date(self.monday),
+                    format_date(self.tuesday),
+                    format_date(self.wednesday),
+                    format_date(self.thursday),
+                    format_date(self.friday),
+                    format_date(self.saturday),
+                    format_date(self.sunday)
+                ));
+            }
+            Weekday::Sun => {
+                output.push_str(&format!(
+                    "{} {} {} {} {} {} {}",
+                    format_date(self.sunday),
+                    format_date(self.monday),
+                    format_date(self.tuesday),
+                    format_date(self.wednesday),
+                    format_date(self.thursday),
+                    format_date(self.friday),
+                    format_date(self.saturday),
+                ));
+            }
+
+            _ => {
+                panic!("Invalid first day of week specified: {}", first_day_of_week);
+            }
+        };
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -499,4 +499,26 @@ mod tests {
                               31                                        
         "###);
     }
+
+    #[test]
+    fn test_determine_start_date_no_args() {
+        let start_date = determine_start_date(None, None, None);
+
+        assert_eq!(start_date, Local::now().date_naive().with_day(1).unwrap());
+    }
+
+    #[test]
+    fn test_determine_start_date_with_months_before() {
+        let start_date = determine_start_date(None, None, Some(1));
+
+        assert_eq!(
+            start_date,
+            Local::now()
+                .date_naive()
+                .with_day(1)
+                .unwrap()
+                .checked_sub_months(chrono::Months::new(1))
+                .unwrap()
+        );
+    }
 }


### PR DESCRIPTION
```
❯ cargo run -- -A 1 -B 1 --first-day-of-week=sunday
     March 2024            April 2024             May 2024      
Su Mo Tu We Th Fr Sa  Su Mo Tu We Th Fr Sa  Su Mo Tu We Th Fr Sa
                1  2      1  2  3  4  5  6            1  2  3  4
 3  4  5  6  7  8  9   7  8  9 10 11 12 13   5  6  7  8  9 10 11
10 11 12 13 14 15 16  14 15 16 17 18 19 20  12 13 14 15 16 17 18
17 18 19 20 21 22 23  21 22 23 24 25 26 27  19 20 21 22 23 24 25
24 25 26 27 28 29 30  28 29 30              26 27 28 29 30 31   
31                                                              


❯ cargo run -- -A 1 -B 1                           
     March 2024            April 2024             May 2024      
Mo Tu We Th Fr Sa Su  Mo Tu We Th Fr Sa Su  Mo Tu We Th Fr Sa Su
             1  2  3   1  2  3  4  5  6  7         1  2  3  4  5
 4  5  6  7  8  9 10   8  9 10 11 12 13 14   6  7  8  9 10 11 12
11 12 13 14 15 16 17  15 16 17 18 19 20 21  13 14 15 16 17 18 19
18 19 20 21 22 23 24  22 23 24 25 26 27 28  20 21 22 23 24 25 26
25 26 27 28 29 30 31  29 30                 27 28 29 30 31      


```

Closes #1 