### PR TITLE
Add support for positional argument.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,6 +91,7 @@ dependencies = [
  "clap",
  "home",
  "insta",
+ "itertools",
  "plist",
 ]
 
@@ -194,6 +195,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "either"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11157ac094ffbdde99aa67b23417ebdd801842852b500e395a45a9c0aac03e4a"
+
+[[package]]
 name = "encode_unicode"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -270,6 +277,15 @@ dependencies = [
  "linked-hash-map",
  "serde",
  "similar",
+]
+
+[[package]]
+name = "itertools"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba291022dbbd398a455acf126c1e341954079855bc60dfdda641363bd6922569"
+dependencies = [
+ "either",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ license = "MIT"
 chrono = "0.4.37"
 clap = { version = "4.5.4", features = ["derive"] }
 home = "0.5.9"
+itertools = "0.12.1"
 plist = "1.6.1"
 
 [dev-dependencies]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,5 @@
 use clap::{Parser, ValueEnum};
+use itertools::Itertools;
 use std::fmt;
 #[cfg(not(test))]
 use std::io::IsTerminal;
@@ -8,14 +9,22 @@ use chrono::prelude::*;
 #[derive(Parser, Debug)]
 #[command(version, about, long_about = None)]
 struct Arguments {
+    /// Display a specific year, quarter, or month.
+    ///
+    /// Disables usage of `--year` and `--month` flags.
+    #[arg(value_parser = parse_date_input, conflicts_with_all = ["year", "month"])]
+    date_input: Option<DateInput>,
+
     /// Sets the first day of the week. If not set, defaults to the system preference.
     #[arg(short, long, value_enum)]
     first_day_of_week: Option<FirstDayOfWeek>,
 
-    #[arg(short, long)]
+    /// The year to display.
+    #[arg(short, long, conflicts_with = "date_input")]
     year: Option<i32>,
 
-    #[arg(short, long, value_parser = clap::value_parser!(u32).range(1..=12))]
+    /// The month to display.
+    #[arg(short, long, value_parser = clap::value_parser!(u32).range(1..=12), conflicts_with = "date_input", requires = "year")]
     month: Option<u32>,
 
     /// Display the number of months after the current month.
@@ -27,7 +36,7 @@ struct Arguments {
     months_before: Option<u32>,
 }
 
-#[derive(Clone, Debug, ValueEnum, PartialEq)]
+#[derive(Clone, Copy, Debug, ValueEnum, PartialEq)]
 enum FirstDayOfWeek {
     Sunday,
     Monday,
@@ -38,6 +47,190 @@ impl From<FirstDayOfWeek> for chrono::Weekday {
         match day {
             FirstDayOfWeek::Sunday => chrono::Weekday::Sun,
             FirstDayOfWeek::Monday => chrono::Weekday::Mon,
+        }
+    }
+}
+
+#[derive(Clone, Debug, PartialEq)]
+enum DateInput {
+    Year(Year),
+    YearMonth(Year, u32),
+    YearQuarter(Year, Quarter),
+}
+
+#[derive(Clone, Debug, PartialEq)]
+enum Quarter {
+    Q1,
+    Q2,
+    Q3,
+    Q4,
+}
+
+#[derive(Clone, Debug, PartialEq)]
+struct Year {
+    style: YearStyle,
+    year: i32,
+}
+
+#[derive(Clone, Debug, PartialEq, Copy)]
+enum YearStyle {
+    Calendar,
+    Fiscal,
+}
+
+fn parse_date_input(s: &str) -> Result<DateInput, String> {
+    // default to calendar year style
+    let style = YearStyle::Calendar;
+
+    // support bare Q1, Q2, Q3, Q4 format
+    if let Some(date) = parse_bare_quarter(s, style) {
+        return Ok(date);
+    }
+
+    // support anything prefixed with FY
+    if let Some(fiscal_year_stripped) = s.strip_prefix("FY") {
+        let style = YearStyle::Fiscal;
+        if let Ok(year) = fiscal_year_stripped.parse::<i32>() {
+            return Ok(DateInput::Year(Year { style, year }));
+        }
+
+        // support bare Q1, Q2, Q3, Q4 format
+        if let Some(date) = parse_bare_quarter(fiscal_year_stripped, style) {
+            return Ok(date);
+        }
+
+        // support FY2024-Q1 format
+        if fiscal_year_stripped.contains("-Q") {
+            if let Some(date) = parse_year_quarter(fiscal_year_stripped, "-Q", style) {
+                return Ok(date);
+            }
+        }
+        // support FY2024Q1 format
+        if fiscal_year_stripped.contains('Q') {
+            if let Some(date) = parse_year_quarter(fiscal_year_stripped, "Q", style) {
+                return Ok(date);
+            }
+        }
+    }
+
+    if let Ok(year) = s.parse::<i32>() {
+        match s.len() {
+            // support 24 format
+            // support 2024 format
+            2 | 4 => {
+                return Ok(DateInput::Year(Year { style, year }));
+            }
+
+            // support 202401 format
+            6 => {
+                let (year, month) = s.split_at(4);
+
+                if let (Ok(year), Ok(month)) = (year.parse::<i32>(), month.parse::<u32>()) {
+                    if (1..=12).contains(&month) {
+                        return Ok(DateInput::YearMonth(Year { style, year }, month));
+                    }
+
+                    return Err(format!(
+                        "Invalid month detected (must be 1 - 12): {}",
+                        month
+                    ));
+                }
+            }
+
+            // fall through to the error case below
+            _ => {}
+        }
+
+        return Err(format!("Invalid date format: {}", s));
+    }
+
+    // support 2024-Q1 format
+    if s.contains("-Q") {
+        if let Some(date) = parse_year_quarter(s, "-Q", style) {
+            return Ok(date);
+        }
+    }
+    // support 2024Q1 format
+    if s.contains('Q') {
+        if let Some(date) = parse_year_quarter(s, "Q", style) {
+            return Ok(date);
+        }
+    }
+
+    // support 2024-01 format
+    if let Some((year, month)) = s.split_once('-') {
+        if let (Ok(year), Ok(month)) = (year.parse::<i32>(), month.parse::<u32>()) {
+            if (1..=12).contains(&month) {
+                return Ok(DateInput::YearMonth(Year { style, year }, month));
+            }
+        }
+    }
+
+    Err(format!("Invalid date format: {}", s))
+}
+
+fn parse_year_quarter(s: &str, delimiter: &str, style: YearStyle) -> Option<DateInput> {
+    if let Some((year, quarter)) = s.split_once(delimiter) {
+        // FIXME: Convert this to an error (change return type to Result<Option>)
+        if let (Ok(year), Some(quarter)) = (
+            year.parse::<i32>(),
+            match quarter {
+                "1" => Some(Quarter::Q1),
+                "2" => Some(Quarter::Q2),
+                "3" => Some(Quarter::Q3),
+                "4" => Some(Quarter::Q4),
+                _ => None,
+            },
+        ) {
+            return Some(DateInput::YearQuarter(Year { style, year }, quarter));
+        }
+    }
+
+    None
+}
+
+fn normalize_short_year(current_date: NaiveDate, year: i32) -> i32 {
+    match year {
+        0..=99 => {
+            let current_year = current_date.year();
+            let current_century = current_year / 100;
+
+            current_century * 100 + year
+        }
+        _ => year,
+    }
+}
+
+fn parse_bare_quarter(s: &str, style: YearStyle) -> Option<DateInput> {
+    if let Some(quarter) = match s.to_uppercase().as_str() {
+        "Q1" => Some(Quarter::Q1),
+        "Q2" => Some(Quarter::Q2),
+        "Q3" => Some(Quarter::Q3),
+        "Q4" => Some(Quarter::Q4),
+        _ => None,
+    } {
+        let year = determine_current_year(style);
+        let year = Year { style, year };
+        return Some(DateInput::YearQuarter(year, quarter));
+    }
+
+    None
+}
+
+fn determine_current_year(style: YearStyle) -> i32 {
+    let today = chrono::Local::now().date_naive();
+    let current_year = today.year();
+
+    match style {
+        YearStyle::Calendar => current_year,
+        YearStyle::Fiscal => {
+            let current_month = today.month();
+
+            if current_month <= 6 {
+                current_year
+            } else {
+                current_year + 1
+            }
         }
     }
 }
@@ -94,38 +287,6 @@ fn determine_default_first_day_of_week(
 
         Weekday::Mon
     }
-}
-
-fn determine_start_date(
-    current_date: NaiveDate,
-    year: Option<i32>,
-    month: Option<u32>,
-    months_before: Option<u32>,
-) -> chrono::NaiveDate {
-    let start_date = match (year, month) {
-        (Some(year), Some(month)) => NaiveDate::from_ymd_opt(year, month, 1)
-            .unwrap_or_else(|| panic!("Invalid year and month combination: {}-{:02}", year, month)),
-        _ => current_date.with_day(1).unwrap(),
-    };
-
-    if let Some(months) = months_before {
-        let start_date = if start_date.month() <= months {
-            NaiveDate::from_ymd_opt(start_date.year() - 1, 12 - months + start_date.month(), 1)
-        } else {
-            NaiveDate::from_ymd_opt(start_date.year(), start_date.month() - months, 1)
-        }
-        .expect("Couldn't determine a valid start date");
-        return start_date;
-    }
-
-    start_date
-}
-
-fn determine_number_of_months(months_after: Option<u32>, months_before: Option<u32>) -> u32 {
-    let months_after = months_after.unwrap_or(0);
-    let months_before = months_before.unwrap_or(0);
-
-    1 + months_before + months_after
 }
 
 #[derive(Debug)]
@@ -352,26 +513,9 @@ impl Week {
     }
 }
 
-fn get_days_in_month(start_date: NaiveDate) -> Vec<NaiveDate> {
-    let end_date = if start_date.month() == 12 {
-        NaiveDate::from_ymd_opt(start_date.year() + 1, 1, 1)
-    } else {
-        NaiveDate::from_ymd_opt(start_date.year(), start_date.month() + 1, 1)
-    };
-
-    let end_date = end_date.expect("Couldn't determine a valid end date");
-
-    let num_days = end_date.signed_duration_since(start_date).num_days();
-
-    (0..num_days)
-        .map(|days| start_date + chrono::Duration::days(days))
-        .collect()
-}
-
-fn build_month(start_date: NaiveDate, first_day_of_week: Weekday) -> Month {
-    let days = get_days_in_month(start_date);
+fn build_month(days: Vec<NaiveDate>, first_day_of_week: Weekday) -> Month {
+    let start_date = *days.first().expect("no days in month");
     let mut weeks: Vec<Week> = vec![];
-
     let mut current_week = Week::new();
 
     for day in days {
@@ -410,31 +554,201 @@ fn build_month(start_date: NaiveDate, first_day_of_week: Weekday) -> Month {
 
 fn build_month_range(
     start_date: NaiveDate,
+    end_date: NaiveDate,
     first_day_of_week: Weekday,
-    num_months: u32,
 ) -> MonthRange {
-    let mut months = vec![];
-    let mut current_date = start_date;
-    for _ in 0..num_months {
-        let month = build_month(current_date, first_day_of_week);
-        months.push(month);
-        current_date = if current_date.month() == 12 {
-            NaiveDate::from_ymd_opt(current_date.year() + 1, 1, 1)
-        } else {
-            NaiveDate::from_ymd_opt(current_date.year(), current_date.month() + 1, 1)
-        }
-        .expect("Couldn't determine a valid end date");
-    }
+    let months: Vec<Month> = date_range(start_date, end_date)
+        .group_by(|&date| (date.year(), date.month()))
+        .into_iter()
+        .map(|((_year, _month), group)| build_month(group.collect(), first_day_of_week))
+        .collect();
 
     MonthRange { months }
 }
 
-fn print(args: Arguments, current_date: NaiveDate) -> String {
-    let first_day_of_week = determine_default_first_day_of_week(args.first_day_of_week);
-    let start_date = determine_start_date(current_date, args.year, args.month, args.months_before);
-    let num_months = determine_number_of_months(args.months_after, args.months_before);
+fn date_range(start: NaiveDate, end: NaiveDate) -> impl Iterator<Item = NaiveDate> {
+    std::iter::successors(Some(start), move |&d| {
+        if d < end {
+            let next = d.succ_opt().unwrap();
 
-    let months = build_month_range(start_date, first_day_of_week, num_months);
+            Some(next)
+        } else {
+            None
+        }
+    })
+}
+
+fn normalize_date_input_for_two_digit_year(
+    current_date: NaiveDate,
+    date_input: Option<DateInput>,
+) -> Option<DateInput> {
+    if let Some(date_input) = date_input {
+        match date_input {
+            DateInput::Year(year) => {
+                let updated_year = normalize_short_year(current_date, year.year);
+
+                return Some(DateInput::Year(Year {
+                    year: updated_year,
+                    ..year
+                }));
+            }
+            DateInput::YearMonth(year, month) => {
+                let updated_year = normalize_short_year(current_date, year.year);
+
+                return Some(DateInput::YearMonth(
+                    Year {
+                        year: updated_year,
+                        ..year
+                    },
+                    month,
+                ));
+            }
+            DateInput::YearQuarter(year, quarter) => {
+                let updated_year = normalize_short_year(current_date, year.year);
+
+                return Some(DateInput::YearQuarter(
+                    Year {
+                        year: updated_year,
+                        ..year
+                    },
+                    quarter,
+                ));
+            }
+        }
+    }
+
+    date_input
+}
+
+fn determine_date_range(current_date: NaiveDate, args: Arguments) -> (NaiveDate, NaiveDate) {
+    // `--year` and `--month` are mutually exclusive with the date_input field, so we can safely
+    // normalize `--year` and `--month` into DateInput::YearMonth without issue
+    let args = match (args.year, args.month) {
+        (Some(year), Some(month)) => {
+            let date = NaiveDate::from_ymd_opt(year, month, 1).unwrap_or_else(|| {
+                panic!("Invalid year and month combination: {}-{:02}", year, month)
+            });
+
+            let date_input = Some(DateInput::YearMonth(
+                Year {
+                    style: YearStyle::Calendar,
+                    year: date.year(),
+                },
+                date.month(),
+            ));
+
+            Arguments { date_input, ..args }
+        }
+        (Some(year), None) => {
+            let date = NaiveDate::from_ymd_opt(year, 1, 1)
+                .unwrap_or_else(|| panic!("Invalid year: {}", year));
+
+            let date_input = Some(DateInput::Year(Year {
+                style: YearStyle::Calendar,
+                year: date.year(),
+            }));
+
+            Arguments { date_input, ..args }
+        }
+        _ => args,
+    };
+
+    // Now populate `date_input` if it isn't present already
+    let args = if args.date_input.is_none() {
+        let date_input = Some(DateInput::YearMonth(
+            Year {
+                style: YearStyle::Calendar,
+                year: current_date.year(),
+            },
+            current_date.month(),
+        ));
+
+        Arguments { date_input, ..args }
+    } else {
+        args
+    };
+
+    let (start_date, end_date) = match args.date_input.expect("Date input is required") {
+        DateInput::Year(year) => (
+            NaiveDate::from_ymd_opt(year.year, 1, 1).unwrap(),
+            NaiveDate::from_ymd_opt(year.year, 12, 31).unwrap(),
+        ),
+        DateInput::YearMonth(year, month) => {
+            let start_date = NaiveDate::from_ymd_opt(year.year, month, 1).unwrap();
+            let end_date = last_day_of_month_for(start_date);
+
+            (start_date, end_date)
+        }
+        DateInput::YearQuarter(year, quarter) => {
+            let (start_month, end_month) = match (year.style, quarter) {
+                (YearStyle::Calendar, Quarter::Q1) => (1, 3),
+                (YearStyle::Calendar, Quarter::Q2) => (4, 6),
+                (YearStyle::Calendar, Quarter::Q3) => (7, 9),
+                (YearStyle::Calendar, Quarter::Q4) => (10, 12),
+                (YearStyle::Fiscal, Quarter::Q1) => (7, 9),
+                (YearStyle::Fiscal, Quarter::Q2) => (10, 12),
+                (YearStyle::Fiscal, Quarter::Q3) => (1, 3),
+                (YearStyle::Fiscal, Quarter::Q4) => (4, 6),
+            };
+
+            let start_date = NaiveDate::from_ymd_opt(year.year, start_month, 1).unwrap();
+            let first_day_of_end_month = NaiveDate::from_ymd_opt(year.year, end_month, 1).unwrap();
+            let end_date = last_day_of_month_for(first_day_of_end_month);
+
+            (start_date, end_date)
+        }
+    };
+
+    let start_date = if let Some(months_before) = args.months_before {
+        if start_date.month() <= months_before {
+            NaiveDate::from_ymd_opt(
+                start_date.year() - 1,
+                12 - months_before + start_date.month(),
+                1,
+            )
+        } else {
+            NaiveDate::from_ymd_opt(start_date.year(), start_date.month() - months_before, 1)
+        }
+        .expect("couldn't determine a valid start date")
+    } else {
+        start_date
+    };
+
+    let end_date = if let Some(months_after) = args.months_after {
+        let end_date = if end_date.month() + months_after > 12 {
+            NaiveDate::from_ymd_opt(end_date.year() + 1, end_date.month() + months_after - 12, 1)
+        } else {
+            NaiveDate::from_ymd_opt(end_date.year(), end_date.month() + months_after, 1)
+        }
+        .expect("couldn't determine a valid end date");
+
+        last_day_of_month_for(end_date)
+    } else {
+        end_date
+    };
+
+    (start_date, end_date)
+}
+
+fn last_day_of_month_for(date: NaiveDate) -> NaiveDate {
+    let (next_month_year, next_month) = if date.month() == 12 {
+        (date.year() + 1, 1)
+    } else {
+        (date.year(), date.month() + 1)
+    };
+    let next_month_start_date = NaiveDate::from_ymd_opt(next_month_year, next_month, 1).unwrap();
+
+    next_month_start_date.pred_opt().unwrap()
+}
+
+fn print(args: Arguments, current_date: NaiveDate) -> String {
+    let date_input = normalize_date_input_for_two_digit_year(current_date, args.date_input);
+
+    let args = Arguments { date_input, ..args };
+    let first_day_of_week = determine_default_first_day_of_week(args.first_day_of_week);
+    let (start_date, end_date) = determine_date_range(current_date, args);
+
+    let months = build_month_range(start_date, end_date, first_day_of_week);
 
     months.print(current_date)
 }
@@ -460,6 +774,225 @@ mod tests {
     }
 
     #[test]
+    fn test_parse_date_input_year() {
+        let style = YearStyle::Calendar;
+
+        assert_eq!(
+            parse_date_input("2024"),
+            Ok(DateInput::Year(Year { style, year: 2024 }))
+        );
+        assert_eq!(
+            parse_date_input("2000"),
+            Ok(DateInput::Year(Year { style, year: 2000 }))
+        );
+    }
+
+    #[test]
+    fn test_parse_date_input_quarter() {
+        let style = YearStyle::Calendar;
+        let year = chrono::Local::now().year();
+
+        assert_eq!(
+            parse_date_input("Q1"),
+            Ok(DateInput::YearQuarter(Year { style, year }, Quarter::Q1))
+        );
+        assert_eq!(
+            parse_date_input("Q2"),
+            Ok(DateInput::YearQuarter(Year { style, year }, Quarter::Q2))
+        );
+        assert_eq!(
+            parse_date_input("Q3"),
+            Ok(DateInput::YearQuarter(Year { style, year }, Quarter::Q3))
+        );
+        assert_eq!(
+            parse_date_input("Q4"),
+            Ok(DateInput::YearQuarter(Year { style, year }, Quarter::Q4))
+        );
+    }
+
+    #[test]
+    fn test_parse_date_input_fiscal_year() {
+        let style = YearStyle::Fiscal;
+
+        assert_eq!(
+            parse_date_input("FY2024"),
+            Ok(DateInput::Year(Year { style, year: 2024 }))
+        );
+        assert_eq!(
+            parse_date_input("FY1900"),
+            Ok(DateInput::Year(Year { style, year: 1900 }))
+        );
+    }
+
+    #[test]
+    fn test_parse_date_input_year_quarter() {
+        let style = YearStyle::Calendar;
+
+        assert_eq!(
+            parse_date_input("2024Q1"),
+            Ok(DateInput::YearQuarter(
+                Year { style, year: 2024 },
+                Quarter::Q1
+            ))
+        );
+        assert_eq!(
+            parse_date_input("2000Q3"),
+            Ok(DateInput::YearQuarter(
+                Year { style, year: 2000 },
+                Quarter::Q3
+            ))
+        );
+        assert_eq!(
+            parse_date_input("1900Q2"),
+            Ok(DateInput::YearQuarter(
+                Year { style, year: 1900 },
+                Quarter::Q2
+            ))
+        );
+    }
+
+    #[test]
+    fn test_parse_date_input_fiscal_quarter() {
+        let style = YearStyle::Fiscal;
+
+        assert_eq!(
+            parse_date_input("FY2024Q1"),
+            Ok(DateInput::YearQuarter(
+                Year { style, year: 2024 },
+                Quarter::Q1
+            ))
+        );
+        assert_eq!(
+            parse_date_input("FY2000Q2"),
+            Ok(DateInput::YearQuarter(
+                Year { style, year: 2000 },
+                Quarter::Q2
+            ))
+        );
+        assert_eq!(
+            parse_date_input("FY1900Q3"),
+            Ok(DateInput::YearQuarter(
+                Year { style, year: 1900 },
+                Quarter::Q3
+            ))
+        );
+        assert_eq!(
+            parse_date_input("FY2024Q4"),
+            Ok(DateInput::YearQuarter(
+                Year { style, year: 2024 },
+                Quarter::Q4
+            ))
+        );
+        assert_eq!(
+            parse_date_input("FY2024-Q1"),
+            Ok(DateInput::YearQuarter(
+                Year { style, year: 2024 },
+                Quarter::Q1
+            ))
+        );
+    }
+
+    #[test]
+    fn test_parse_date_input_year_month() {
+        let style = YearStyle::Calendar;
+
+        assert_eq!(
+            parse_date_input("2024-01"),
+            Ok(DateInput::YearMonth(Year { style, year: 2024 }, 1))
+        );
+        assert_eq!(
+            parse_date_input("202401"),
+            Ok(DateInput::YearMonth(Year { style, year: 2024 }, 1))
+        );
+        assert_eq!(
+            parse_date_input("2000-06"),
+            Ok(DateInput::YearMonth(Year { style, year: 2000 }, 6))
+        );
+        assert_eq!(
+            parse_date_input("200006"),
+            Ok(DateInput::YearMonth(Year { style, year: 2000 }, 6))
+        );
+        assert_eq!(
+            parse_date_input("1900-12"),
+            Ok(DateInput::YearMonth(Year { style, year: 1900 }, 12))
+        );
+        assert_eq!(
+            parse_date_input("190012"),
+            Ok(DateInput::YearMonth(Year { style, year: 1900 }, 12))
+        );
+    }
+
+    #[test]
+    #[ignore]
+    fn test_parse_date_two_digit_year() {
+        assert_eq!(
+            parse_date_input("FY24Q1"),
+            Ok(DateInput::YearQuarter(
+                Year {
+                    style: YearStyle::Fiscal,
+                    year: 2024
+                },
+                Quarter::Q1
+            ))
+        );
+
+        assert_eq!(
+            parse_date_input("FY25Q2"),
+            Ok(DateInput::YearQuarter(
+                Year {
+                    style: YearStyle::Fiscal,
+                    year: 2025
+                },
+                Quarter::Q2
+            ))
+        );
+
+        assert_eq!(
+            parse_date_input("FY24"),
+            Ok(DateInput::Year(Year {
+                style: YearStyle::Fiscal,
+                year: 2024
+            },))
+        );
+
+        assert_eq!(
+            parse_date_input("FY25"),
+            Ok(DateInput::Year(Year {
+                style: YearStyle::Fiscal,
+                year: 2025
+            },))
+        );
+
+        assert_eq!(
+            parse_date_input("25Q2"),
+            Ok(DateInput::YearQuarter(
+                Year {
+                    style: YearStyle::Calendar,
+                    year: 2025
+                },
+                Quarter::Q2
+            ))
+        );
+
+        assert_eq!(
+            parse_date_input("24"),
+            Ok(DateInput::Year(Year {
+                style: YearStyle::Calendar,
+                year: 2024
+            },))
+        );
+    }
+
+    #[test]
+    fn test_parse_date_input_invalid() {
+        assert!(parse_date_input("").is_err());
+        assert!(parse_date_input("invalid").is_err());
+        assert!(parse_date_input("2024-13").is_err());
+        assert!(parse_date_input("FY").is_err());
+        assert!(parse_date_input("Q5").is_err());
+    }
+
+    #[test]
     fn test_month_print_simple() {
         let current_date = NaiveDate::from_ymd_opt(2024, 3, 20).unwrap();
         let args = args(["cal"]);
@@ -472,6 +1005,22 @@ mod tests {
         11 12 13 14 15 16 17
         18 19 20 21 22 23 24
         25 26 27 28 29 30 31
+        "###);
+    }
+
+    #[test]
+    fn test_print_quarter() {
+        let current_date = NaiveDate::from_ymd_opt(2024, 5, 20).unwrap();
+        let args = args(["cal", "Q1"]);
+
+        insta::assert_snapshot!(print(args, current_date), @r###"
+            January 2024         February 2024           March 2024     
+        Mo Tu We Th Fr Sa Su  Mo Tu We Th Fr Sa Su  Mo Tu We Th Fr Sa Su
+         1  2  3  4  5  6  7            1  2  3  4               1  2  3
+         8  9 10 11 12 13 14   5  6  7  8  9 10 11   4  5  6  7  8  9 10
+        15 16 17 18 19 20 21  12 13 14 15 16 17 18  11 12 13 14 15 16 17
+        22 23 24 25 26 27 28  19 20 21 22 23 24 25  18 19 20 21 22 23 24
+        29 30 31              26 27 28 29           25 26 27 28 29 30 31
         "###);
     }
 
@@ -555,28 +1104,5 @@ mod tests {
         25 26 27 28 29        24 25 26 27 28 29 30  28 29 30            
                               31                                        
         "###);
-    }
-
-    #[test]
-    fn test_determine_start_date_no_args() {
-        let current_date = NaiveDate::from_ymd_opt(2024, 3, 20).unwrap();
-        let start_date = determine_start_date(current_date, None, None, None);
-
-        assert_eq!(start_date, current_date.with_day(1).unwrap());
-    }
-
-    #[test]
-    fn test_determine_start_date_with_months_before() {
-        let current_date = NaiveDate::from_ymd_opt(2024, 3, 20).unwrap();
-        let start_date = determine_start_date(current_date, None, None, Some(1));
-
-        assert_eq!(
-            start_date,
-            current_date
-                .with_day(1)
-                .unwrap()
-                .checked_sub_months(chrono::Months::new(1))
-                .unwrap()
-        );
     }
 }


### PR DESCRIPTION
Supports a number of calling patterns:

```
cal Q3
cal 24
cal 24Q2
cal 2024-Q3
cal 2024
cal 2024-01
cal FY24Q3
cal FY2024
cal FY2024Q1
cal FY2024-Q1
cal FYQ3
```

Resolves #7 