### PR TITLE
Refactor "today" determination

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -91,7 +91,6 @@ dependencies = [
  "clap",
  "home",
  "insta",
- "lazy_static",
  "plist",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,6 @@ license = "MIT"
 chrono = "0.4.37"
 clap = { version = "4.5.4", features = ["derive"] }
 home = "0.5.9"
-lazy_static = "1.4.0"
 plist = "1.6.1"
 
 [dev-dependencies]


### PR DESCRIPTION
Instead of using `lazy_static` to declare the `TODAY` static ref, this splits things up so that `main` defaults to the current date but the new `print` function accepts a substitute "current date".

This allows the acceptance tests to be refactored to be much much closer to reality (e.g. they actually go through the args parsing).
