### PR TITLE
Add `--color` command line option

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,12 @@ Options:
   -B, --months-before <MONTHS_BEFORE>
           Display the number of months before the current month
 
+      --color[=<WHEN>]
+          Enable or disable colored output
+          
+          [default: auto]
+          [possible values: always, auto, never]
+
   -h, --help
           Print help (see a summary with '-h')
 


### PR DESCRIPTION
Supports `auto` (default), `always`, and `never`. Also includes support
for checking `FORCE_COLOR` environment variable (`0` is the same as
  `never`, and `1` is the same as `always`).
