### PR TITLE
Ensure fiscal year works properly

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v0.2.0 (Unreleased)
 
 - Migrate linux builds from GLIBC to MUSL
+- Ensure fiscal year works properly
 
 ## v0.1.0 (2024-04-07)
 


### PR DESCRIPTION
Previously, `cal FY25Q1` would say that it started in July 2025, but it should be July 2024.
